### PR TITLE
Fix example local absolute path

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   flutter:
     sdk: flutter
   graphview:
-    path: /Users/photobook/AndroidStudioProjects/graphview/
+    path: ../
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Hello @nabil6391 ✋🏻 
I start learn your package using a ready made example. 
But path of package in example pubspec.yaml used your local absolute path.

Using a relative path will help with start learning your package quickly.