### PR TITLE
Update GraphView.dart

### DIFF
--- a/lib/GraphView.dart
+++ b/lib/GraphView.dart
@@ -47,8 +47,7 @@ class GraphView extends StatefulWidget {
   final bool animated;
 
   GraphView(
-      {Key? key, required this.graph, required this.algorithm, this.paint, required this.builder, this.animated = true})
-      : super(key: key);
+      {Key? key, required this.graph, required this.algorithm, this.paint, required this.builder, this.animated = true});
 
   @override
   _GraphViewState createState() => _GraphViewState();


### PR DESCRIPTION
key is being passed to super class as well and also to other widgets in build method leading to this [issue](https://github.com/nabil6391/graphview/issues/85).