### PR TITLE
Potential fix for graph flickering

### DIFF
--- a/lib/GraphView.dart
+++ b/lib/GraphView.dart
@@ -239,14 +239,11 @@ class _GraphViewAnimated extends StatefulWidget {
   final Graph graph;
   final Algorithm algorithm;
   final Paint? paint;
-  final nodes = <Widget>[];
+  final NodeWidgetBuilder builder;
   final stepMilis = 25;
 
   _GraphViewAnimated(
-      {Key? key, required this.graph, required this.algorithm, this.paint, required NodeWidgetBuilder builder}) {
-    graph.nodes.forEach((node) {
-      nodes.add(node.data ?? builder(node));
-    });
+      {Key? key, required this.graph, required this.algorithm, this.paint, required this.builder}) {
   }
 
   @override
@@ -296,7 +293,7 @@ class _GraphViewAnimatedState extends State<_GraphViewAnimated> {
         ...List<Widget>.generate(graph.nodeCount(), (index) {
           return Positioned(
             child: GestureDetector(
-              child: widget.nodes[index],
+              child: graph.nodes[index].data ?? widget.builder(graph.nodes[index]),
               onPanUpdate: (details) {
                 graph.getNodeAtPosition(index).position += details.delta;
                 update();

--- a/lib/forcedirected/FruchtermanReingoldAlgorithm.dart
+++ b/lib/forcedirected/FruchtermanReingoldAlgorithm.dart
@@ -88,7 +88,7 @@ class FruchtermanReingoldAlgorithm implements Algorithm {
       var deltaDistance = max(EPSILON, delta.distance);
       var maxAttractionDistance = min(graphWidth * attractionPercentage, graphHeight * attractionPercentage);
       var attractionForce = min(0, (maxAttractionDistance - deltaDistance)).abs() / (maxAttractionDistance * 2);
-      var attractionVector = delta * attractionForce * attractionRate;
+      var attractionVector = delta * attractionForce * attractionRate * 0.5; // https://github.com/nabil6391/graphview/issues/111
 
       displacement[source] = displacement[source]! - attractionVector;
       displacement[destination] = displacement[destination]! + attractionVector;

--- a/lib/forcedirected/FruchtermanReingoldAlgorithm.dart
+++ b/lib/forcedirected/FruchtermanReingoldAlgorithm.dart
@@ -3,7 +3,7 @@ part of graphview;
 const int DEFAULT_ITERATIONS = 1000;
 const double REPULSION_RATE = 0.5;
 const double REPULSION_PERCENTAGE = 0.4;
-const double ATTRACTION_RATE = 0.15;
+const double ATTRACTION_RATE = 0.15 * 0.5; // https://github.com/nabil6391/graphview/issues/111
 const double ATTRACTION_PERCENTAGE = 0.15;
 const int CLUSTER_PADDING = 15;
 const double EPSILON = 0.0001;
@@ -88,7 +88,7 @@ class FruchtermanReingoldAlgorithm implements Algorithm {
       var deltaDistance = max(EPSILON, delta.distance);
       var maxAttractionDistance = min(graphWidth * attractionPercentage, graphHeight * attractionPercentage);
       var attractionForce = min(0, (maxAttractionDistance - deltaDistance)).abs() / (maxAttractionDistance * 2);
-      var attractionVector = delta * attractionForce * attractionRate * 0.5; // https://github.com/nabil6391/graphview/issues/111
+      var attractionVector = delta * attractionForce * attractionRate;
 
       displacement[source] = displacement[source]! - attractionVector;
       displacement[destination] = displacement[destination]! + attractionVector;


### PR DESCRIPTION
Many of my graphs were flickering between two states. By reducing the attraction travel distance, we prevent the situation where the algorithm can oscillate between two stable values.
Probably warrants further testing, but seems to have solved the problem for my graphs.