### PR TITLE
Add option for different types of lines for Sugiyama

### DIFF
--- a/lib/Graph.dart
+++ b/lib/Graph.dart
@@ -163,6 +163,8 @@ class Node {
 
   Offset position = Offset(0, 0);
 
+  String lineType = 'default';
+
   double get height => size.height;
 
   double get width => size.width;
@@ -189,7 +191,7 @@ class Node {
 
   @override
   String toString() {
-    return 'Node{position: $position, key: $key, _size: $size}';
+    return 'Node{position: $position, key: $key, _size: $size, lineType: $lineType}';
   }
 }
 

--- a/lib/GraphView.dart
+++ b/lib/GraphView.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'dart:ui';
 import 'package:collection/collection.dart' show IterableExtension;
 
 part 'Graph.dart';

--- a/lib/layered/SugiyamaAlgorithm.dart
+++ b/lib/layered/SugiyamaAlgorithm.dart
@@ -85,7 +85,7 @@ class SugiyamaAlgorithm extends Algorithm {
   void initSugiyamaData() {
     graph.nodes.forEach((node) {
       node.position = Offset(0, 0);
-      nodeData[node] = SugiyamaNodeData();
+      nodeData[node] = SugiyamaNodeData(node.lineType);
     });
 
     graph.edges.forEach((edge) {
@@ -149,7 +149,7 @@ class SugiyamaAlgorithm extends Algorithm {
         while (iterator.moveNext()) {
           final edge = iterator.current;
           final dummy = Node.Id(dummyId.hashCode);
-          final dummyNodeData = SugiyamaNodeData();
+          final dummyNodeData = SugiyamaNodeData(node.lineType);
           dummyNodeData.isDummy = true;
           dummyNodeData.layer = indexNextLayer;
           nextLayer.add(dummy);

--- a/lib/layered/SugiyamaEdgeRenderer.dart
+++ b/lib/layered/SugiyamaEdgeRenderer.dart
@@ -53,9 +53,6 @@ class SugiyamaEdgeRenderer extends ArrowEdgeRenderer {
               bendPoints[size - 4], bendPoints[size - 3], bendPoints[size - 2], bendPoints[size - 1], destination);
         }
 
-        final triangleCentroid = drawTriangle(
-            canvas, edgeTrianglePaint ?? trianglePaint, clippedLine[0], clippedLine[1], clippedLine[2], clippedLine[3]);
-
         path.reset();
         path.moveTo(bendPoints[0], bendPoints[1]);
 
@@ -95,8 +92,6 @@ class SugiyamaEdgeRenderer extends ArrowEdgeRenderer {
           final stopY = y1 + destination.height / 2;
           path.lineTo(stopX, stopY);
         }
-        // path.lineTo(triangleCentroid[0], triangleCentroid[1]);
-        path.lineTo(triangleCentroid[0], triangleCentroid[1]);
         canvas.drawPath(path, currentPaint);
       } else {
         final startX = x + source.width / 2;
@@ -106,37 +101,47 @@ class SugiyamaEdgeRenderer extends ArrowEdgeRenderer {
 
         clippedLine = clipLine(startX, startY, stopX, stopY, destination);
 
+        var destinationPoint = Offset(stopX, stopY);
+
         if (addTriangleToEdge) {
           final triangleCentroid = drawTriangle(
               canvas, edgeTrianglePaint ?? trianglePaint, clippedLine[0],
               clippedLine[1], clippedLine[2], clippedLine[3]);
 
-          canvas.drawLine(
-              Offset(clippedLine[0], clippedLine[1]), Offset(triangleCentroid[0], triangleCentroid[1]), currentPaint);
-        } else {
-          canvas.drawLine(
-              Offset(clippedLine[0], clippedLine[1]), Offset(stopX, stopY), currentPaint);
-        // final triangleCentroid = drawTriangle(
-        //     canvas, edgeTrianglePaint ?? trianglePaint, clippedLine[0], clippedLine[1], clippedLine[2], clippedLine[3]);
+          destinationPoint = Offset(triangleCentroid[0], triangleCentroid[1]);
+        }
 
-        // canvas.drawLine(
-        //     Offset(clippedLine[0], clippedLine[1]), Offset(triangleCentroid[0], triangleCentroid[1]), currentPaint);
-
+        // Draw the line
         switch (nodeData[destination]?.lineType.toUpperCase()) {
           case 'DASHEDLINE':
-            _drawDashedLine(canvas, Offset(clippedLine[0], clippedLine[1]), Offset(stopX, stopY), currentPaint, 0.6);
+            _drawDashedLine(
+                canvas,
+                Offset(clippedLine[0], clippedLine[1]), destinationPoint,
+                currentPaint, 0.6
+            );
             break;
           case 'DOTTEDLINE':
-            _drawDashedLine(canvas, Offset(clippedLine[0], clippedLine[1]), Offset(stopX, stopY), currentPaint, 0.0);
+            // dotted line uses the same method as dashed line, but with a lineLength of 0.0
+            _drawDashedLine(
+                canvas,
+                Offset(clippedLine[0], clippedLine[1]), destinationPoint,
+                currentPaint, 0.0
+            );
             break;
           case 'SINELINE':
-            _drawSineLine(canvas, Offset(clippedLine[0], clippedLine[1]), Offset(stopX, stopY), currentPaint);
+            _drawSineLine(
+                canvas,
+                Offset(clippedLine[0], clippedLine[1]), destinationPoint,
+                currentPaint
+            );
             break;
           default:
-            canvas.drawLine(Offset(clippedLine[0], clippedLine[1]), Offset(stopX, stopY), currentPaint);
+            canvas.drawLine(
+                Offset(clippedLine[0], clippedLine[1]), destinationPoint,
+                currentPaint
+            );
             break;
         }
-      }
     }});
   }
 
@@ -242,7 +247,6 @@ class SugiyamaEdgeRenderer extends ArrowEdgeRenderer {
         source = segmentDestination;
         phase += pi * segmentLength / lineLength;
       }
-
       canvas.drawPath(path, paint);
     }
   }

--- a/lib/layered/SugiyamaEdgeRenderer.dart
+++ b/lib/layered/SugiyamaEdgeRenderer.dart
@@ -1,5 +1,6 @@
 part of graphview;
 
+
 class SugiyamaEdgeRenderer extends ArrowEdgeRenderer {
   Map<Node, SugiyamaNodeData> nodeData;
   Map<Edge, SugiyamaEdgeData> edgeData;
@@ -15,7 +16,7 @@ class SugiyamaEdgeRenderer extends ArrowEdgeRenderer {
     var trianglePaint = Paint()
       ..color = paint.color
       ..style = PaintingStyle.fill;
-
+      
     graph.edges.forEach((edge) {
       final source = edge.source;
 
@@ -51,6 +52,9 @@ class SugiyamaEdgeRenderer extends ArrowEdgeRenderer {
           clippedLine = clipLine(
               bendPoints[size - 4], bendPoints[size - 3], bendPoints[size - 2], bendPoints[size - 1], destination);
         }
+
+        // final triangleCentroid = drawTriangle(
+        //     canvas, edgeTrianglePaint ?? trianglePaint, clippedLine[0], clippedLine[1], clippedLine[2], clippedLine[3]);
 
         path.reset();
         path.moveTo(bendPoints[0], bendPoints[1]);
@@ -91,6 +95,7 @@ class SugiyamaEdgeRenderer extends ArrowEdgeRenderer {
           final stopY = y1 + destination.height / 2;
           path.lineTo(stopX, stopY);
         }
+        // path.lineTo(triangleCentroid[0], triangleCentroid[1]);
         canvas.drawPath(path, currentPaint);
       } else {
         final startX = x + source.width / 2;
@@ -110,9 +115,19 @@ class SugiyamaEdgeRenderer extends ArrowEdgeRenderer {
         } else {
           canvas.drawLine(
               Offset(clippedLine[0], clippedLine[1]), Offset(stopX, stopY), currentPaint);
+        switch (nodeData[destination]?.lineType.toUpperCase()) {
+          case 'DASHEDONE':
+            _drawDashedLine(canvas, Offset(clippedLine[0], clippedLine[1]), Offset(stopX, stopY), currentPaint, 0.6);
+            break;
+          case 'DASHEDTWO':
+            _drawDashedLine(canvas, Offset(clippedLine[0], clippedLine[1]), Offset(stopX, stopY), currentPaint, 0.3);
+            break;
+          default:
+            canvas.drawLine(Offset(clippedLine[0], clippedLine[1]), Offset(stopX, stopY), currentPaint);
+            break;
         }
       }
-    });
+    }});
   }
 
   void _drawSharpBendPointsEdge(List<Offset> bendPoints) {
@@ -152,4 +167,28 @@ class SugiyamaEdgeRenderer extends ArrowEdgeRenderer {
       }
     }
   }
+
+  void _drawDashedLine(Canvas canvas, Offset source, Offset destination, Paint paint, double lineLength) {
+    var numLines = 14;
+
+    // Calculate the distance between the source and destination points
+    var dx = destination.dx - source.dx;
+    var dy = destination.dy - source.dy;
+    
+    // Calculate the step size for each line
+    var stepX = dx / (numLines - 1);
+    var stepY = dy / (numLines - 1);
+
+    // Draw the lines between the two points
+    Iterable<int>.generate(numLines).map((i) {
+      var startX = source.dx + (i * stepX);
+      var startY = source.dy + (i * stepY);
+      var endX = startX + (stepX * lineLength);
+      var endY = startY + (stepY * lineLength);
+      return [Offset(startX, startY), Offset(endX, endY)];
+    }).forEach((points) => canvas.drawLine(points[0], points[1], paint));
+    
+  }
+
+
 }

--- a/lib/layered/SugiyamaEdgeRenderer.dart
+++ b/lib/layered/SugiyamaEdgeRenderer.dart
@@ -183,31 +183,46 @@ class SugiyamaEdgeRenderer extends ArrowEdgeRenderer {
     }
   }
 
-  void _drawDashedLine(Canvas canvas, Offset source, Offset destination, Paint paint, double lineLength) {
-    var numLines = 14;
 
-    // lineLength == 0.0 to use dotted lines
+void _drawDashedLine(Canvas canvas, Offset source, Offset destination, Paint paint, double lineLength) {
+  // Calculate the distance between the source and destination points
+  var dx = destination.dx - source.dx;
+  var dy = destination.dy - source.dy;
+
+  // Calculate the Euclidean distance
+  var distance = sqrt(dx * dx + dy * dy);
+
+  var numLines = lineLength == 0.0 ? (distance / 5).ceil() : 14;
+
+  // Calculate the step size for each line
+  var stepX = dx / numLines;
+  var stepY = dy / numLines;
+
+  // Set a fixed radius for the circles
+  var circleRadius = 1.0;
+
+  // Set a fixed stroke width for the circles
+  var circleStrokeWidth = 1.0;
+  var circlePaint = Paint()
+    ..color = paint.color
+    ..strokeWidth = circleStrokeWidth
+    ..style = PaintingStyle.fill; // Change to fill style
+
+  // Draw the lines or dots between the two points
+  Iterable<int>.generate(numLines).forEach((i) {
+    var startX = source.dx + (i * stepX);
+    var startY = source.dy + (i * stepY);
     if (lineLength == 0.0) {
-      numLines = 40;
-    }
-
-    // Calculate the distance between the source and destination points
-    var dx = destination.dx - source.dx;
-    var dy = destination.dy - source.dy;
-
-    // Calculate the step size for each line
-    var stepX = dx / numLines;
-    var stepY = dy / numLines;
-
-    // Draw the lines between the two points
-    Iterable<int>.generate(numLines).map((i) {
-      var startX = source.dx + (i * stepX);
-      var startY = source.dy + (i * stepY);
+      // Draw a dot with a fixed radius and stroke width
+      canvas.drawCircle(Offset(startX, startY), circleRadius, circlePaint);
+    } else {
+      // Draw a dash
       var endX = startX + (stepX * lineLength);
       var endY = startY + (stepY * lineLength);
-      return [Offset(startX, startY), Offset(endX, endY)];
-    }).forEach((points) => canvas.drawLine(points[0], points[1], paint));
-  }
+      canvas.drawLine(Offset(startX, startY), Offset(endX, endY), paint);
+    }
+  });
+}
 
   void _drawSineLine(Canvas canvas, Offset source, Offset destination, Paint paint) {
     paint..strokeWidth = 1.5;

--- a/lib/layered/SugiyamaNodeData.dart
+++ b/lib/layered/SugiyamaNodeData.dart
@@ -8,11 +8,14 @@ class SugiyamaNodeData {
   int position = -1;
   List<Node> predecessorNodes = [];
   List<Node> successorNodes = [];
+  String lineType;
+
+  SugiyamaNodeData(this.lineType);
 
   bool get isReversed => reversed.isNotEmpty;
 
   @override
   String toString() {
-    return 'SugiyamaNodeData{reversed: $reversed, isDummy: $isDummy, median: $median, layer: $layer, position: $position';
+    return 'SugiyamaNodeData{reversed: $reversed, isDummy: $isDummy, median: $median, layer: $layer, position: $position, lineType: $lineType}';
   }
 }


### PR DESCRIPTION
Added dot, dash and sine line options for Sugiyama graph.
If the lineType property is not supplied, the normal line is drawn.
Does not work for curved lines, only for straight edges from node to node.