### PR TITLE
Add dartdoc comments to public API (7% → 35.7% coverage)

### DIFF
--- a/lib/Algorithm.dart
+++ b/lib/Algorithm.dart
@@ -1,15 +1,23 @@
 part of graphview;
 
+/// Abstract base class for graph layout algorithms.
+///
+/// Implementations position nodes by setting [Node.position] and [Node.size]
+/// for every node in the graph. The typical lifecycle is:
+/// `init(graph) → setDimensions(w, h) → run(graph, shiftX, shiftY)`.
 abstract class Algorithm {
+  /// The edge renderer used to draw connections between nodes.
   EdgeRenderer? renderer;
 
-  /// Executes the algorithm.
-  /// @param shiftY Shifts the y-coordinate origin
-  /// @param shiftX Shifts the x-coordinate origin
-  /// @return The size of the graph
+  /// Executes the algorithm, positioning all nodes in the [graph].
+  ///
+  /// [shiftX] and [shiftY] offset the coordinate origin.
+  /// Returns the bounding [Size] of the laid-out graph.
   Size run(Graph? graph, double shiftX, double shiftY);
 
+  /// Initializes internal data structures for the given [graph].
   void init(Graph? graph);
 
+  /// Sets the available viewport dimensions for layout computation.
   void setDimensions(double width, double height);
 }

--- a/lib/Graph.dart
+++ b/lib/Graph.dart
@@ -1,8 +1,14 @@
 part of graphview;
 
+/// A directed graph data structure composed of [Node]s connected by [Edge]s.
+///
+/// Maintains cached successor/predecessor lookups that are automatically
+/// invalidated when the graph structure changes.
 class Graph {
   final List<Node> _nodes = [];
   final List<Edge> _edges = [];
+
+  /// Observers notified when the graph structure changes.
   List<GraphObserver> graphObserver = [];
 
   // Cache
@@ -10,22 +16,29 @@ class Graph {
   final Map<Node, List<Node>> _predecessorCache = {};
   bool _cacheValid = false;
 
+  /// All nodes in this graph.
   List<Node> get nodes => _nodes;
 
+  /// All edges in this graph.
   List<Edge> get edges => _edges;
 
+  /// Whether this graph represents a tree (enables recursive removal).
   var isTree = false;
 
+  /// Returns the number of nodes in this graph.
   int nodeCount() => _nodes.length;
 
+  /// Adds a [node] to the graph and invalidates caches.
   void addNode(Node node) {
     _nodes.add(node);
     _cacheValid = false;
     notifyGraphObserver();
   }
 
+  /// Adds multiple [nodes] to the graph.
   void addNodes(List<Node> nodes) => nodes.forEach((it) => addNode(it));
 
+  /// Removes a [node] and its connected edges. If [isTree], also removes successors.
   void removeNode(Node? node) {
     if (!_nodes.contains(node)) return;
 
@@ -40,14 +53,17 @@ class Graph {
     notifyGraphObserver();
   }
 
+  /// Removes multiple [nodes] from the graph.
   void removeNodes(List<Node> nodes) => nodes.forEach((it) => removeNode(it));
 
+  /// Creates and adds an edge from [source] to [destination] with optional [paint].
   Edge addEdge(Node source, Node destination, {Paint? paint}) {
     final edge = Edge(source, destination, paint: paint);
     addEdgeS(edge);
     return edge;
   }
 
+  /// Adds an existing [edge] to the graph, auto-adding missing source/destination nodes.
   void addEdgeS(Edge edge) {
     var sourceSet = false;
     var destinationSet = false;
@@ -85,37 +101,47 @@ class Graph {
     }
   }
 
+  /// Adds multiple [edges] to the graph.
   void addEdges(List<Edge> edges) => edges.forEach((it) => addEdgeS(it));
 
+  /// Removes an [edge] from the graph.
   void removeEdge(Edge edge) {
     _edges.remove(edge);
     _cacheValid = false;
   }
 
+  /// Removes multiple [edges] from the graph.
   void removeEdges(List<Edge> edges) => edges.forEach((it) => removeEdge(it));
 
+  /// Removes the edge connecting [predecessor] to [current].
   void removeEdgeFromPredecessor(Node? predecessor, Node? current) {
     _edges.removeWhere(
         (edge) => edge.source == predecessor && edge.destination == current);
     _cacheValid = false;
   }
 
+  /// Whether this graph contains any nodes.
   bool hasNodes() => _nodes.isNotEmpty;
 
+  /// Returns the edge from [source] to [destination], or null if none exists.
   Edge? getEdgeBetween(Node source, Node? destination) =>
       _edges.firstWhereOrNull((element) =>
           element.source == source && element.destination == destination);
 
+  /// Whether [node] has any successors (outgoing edges).
   bool hasSuccessor(Node? node) => successorsOf(node).isNotEmpty;
 
+  /// Returns all successor nodes of [node] (nodes reachable via outgoing edges).
   List<Node> successorsOf(Node? node) {
     if (node == null) return [];
     if (!_cacheValid) _buildCache();
     return _successorCache[node] ?? [];
   }
 
+  /// Whether [node] has any predecessors (incoming edges).
   bool hasPredecessor(Node node) => predecessorsOf(node).isNotEmpty;
 
+  /// Returns all predecessor nodes of [node] (nodes with edges pointing to it).
   List<Node> predecessorsOf(Node? node) {
     if (node == null) return [];
     if (!_cacheValid) _buildCache();
@@ -139,12 +165,15 @@ class Graph {
     _cacheValid = true;
   }
 
+  /// Whether the graph contains the given [node] or [edge].
   bool contains({Node? node, Edge? edge}) =>
       node != null && _nodes.contains(node) ||
       edge != null && _edges.contains(edge);
 
+  /// Whether any node in the graph has the given [data] widget.
   bool containsData(data) => _nodes.any((element) => element.data == data);
 
+  /// Returns the node at the given list [position].
   Node getNodeAtPosition(int position) {
     if (position < 0) {
 //            throw IllegalArgumentException("position can't be negative")
@@ -162,22 +191,28 @@ class Graph {
   Node getNodeAtUsingData(Widget data) =>
       _nodes.firstWhere((element) => element.data == data);
 
+  /// Returns the node matching the given [key].
   Node getNodeUsingKey(ValueKey key) =>
       _nodes.firstWhere((element) => element.key == key);
 
+  /// Returns the node whose key wraps the given [id].
   Node getNodeUsingId(dynamic id) =>
       _nodes.firstWhere((element) => element.key == ValueKey(id));
 
+  /// Returns all outgoing edges from [node].
   List<Edge> getOutEdges(Node node) =>
       _edges.where((element) => element.source == node).toList();
 
+  /// Returns all incoming edges to [node].
   List<Edge> getInEdges(Node node) =>
       _edges.where((element) => element.destination == node).toList();
 
+  /// Notifies all registered [graphObserver]s that the graph has changed.
   void notifyGraphObserver() => graphObserver.forEach((element) {
         element.notifyGraphInvalidated();
       });
 
+  /// Serializes the graph to a JSON string with node hashes and edge mappings.
   String toJson() {
     var jsonString = {
       'nodes': [..._nodes.map((e) => e.hashCode.toString())],
@@ -194,7 +229,9 @@ class Graph {
 
 }
 
+/// Extension methods for computing graph geometry.
 extension GraphExtension on Graph {
+  /// Returns the bounding rectangle that encloses all nodes.
   Rect calculateGraphBounds() {
     var minX = double.infinity;
     var minY = double.infinity;
@@ -211,20 +248,31 @@ extension GraphExtension on Graph {
     return Rect.fromLTRB(minX, minY, maxX, maxY);
   }
 
+  /// Returns the total size of the graph based on its bounding rectangle.
   Size calculateGraphSize() {
     final bounds = calculateGraphBounds();
     return bounds.size;
   }
 }
 
+/// Visual style for edge and connection lines.
 enum LineType {
+  /// Solid continuous line.
   Default,
+  /// Dotted line with small circle segments.
   DottedLine,
+  /// Dashed line with alternating segments.
   DashedLine,
+  /// Sine wave pattern line.
   SineLine,
 }
 
+/// A vertex in a [Graph], identified by a [ValueKey].
+///
+/// Use [Node.Id] to create nodes with a unique identifier.
+/// The layout algorithm sets [position] and [size] during execution.
 class Node {
+  /// Unique identifier for this node. Two nodes with the same key value are equal.
   ValueKey? key;
 
   @Deprecated('Please use the builder and id mechanism to build the widgets')
@@ -235,14 +283,18 @@ class Node {
     this.key = ValueKey(key?.hashCode ?? data.hashCode);
   }
 
+  /// Creates a node with the given [id] as its identity key.
   Node.Id(dynamic id) {
     key = ValueKey(id);
   }
 
+  /// The measured size of this node's widget, set during layout.
   Size size = Size(0, 0);
 
+  /// The computed position of this node, set by the layout algorithm.
   Offset position = Offset(0, 0);
 
+  /// The visual line style used when rendering edges to this node.
   LineType lineType = LineType.Default;
 
   double get height => size.height;
@@ -276,13 +328,21 @@ class Node {
   }
 }
 
+/// A directed connection between two [Node]s in a [Graph].
 class Edge {
+  /// The origin node of this edge.
   Node source;
+
+  /// The target node of this edge.
   Node destination;
 
+  /// Optional key for identity comparison (overrides hash-based equality).
   Key? key;
+
+  /// Optional custom paint for rendering this edge with specific colors or stroke width.
   Paint? paint;
 
+  /// Creates an edge from [source] to [destination].
   Edge(this.source, this.destination, {this.key, this.paint});
 
   @override
@@ -293,6 +353,8 @@ class Edge {
   int get hashCode => key?.hashCode ?? Object.hash(source, destination);
 }
 
+/// Observer interface for receiving notifications when a [Graph] structure changes.
 abstract class GraphObserver {
+  /// Called when the graph's node or edge structure has been modified.
   void notifyGraphInvalidated();
 }

--- a/lib/GraphView.dart
+++ b/lib/GraphView.dart
@@ -1,3 +1,5 @@
+/// A Flutter library for displaying data in graph structures including
+/// trees, directed graphs, layered graphs, mindmaps, and radial layouts.
 library graphview;
 
 import 'dart:async';
@@ -33,18 +35,34 @@ part 'tree/RadialTreeLayoutAlgorithm.dart';
 part 'tree/TidierTreeLayoutAlgorithm.dart';
 part 'tree/TreeEdgeRenderer.dart';
 
+/// Builder function that creates a widget for a given [Node].
 typedef NodeWidgetBuilder = Widget Function(Node node);
+
+/// Builder function that creates a widget for a given [Edge].
 typedef EdgeWidgetBuilder = Widget Function(Edge edge);
 
+/// Controls a [GraphView] widget programmatically.
+///
+/// Provides methods for navigation ([jumpToNode], [animateToNode], [zoomToFit]),
+/// node visibility ([collapseNode], [expandNode], [toggleNodeExpanded]),
+/// and view manipulation ([resetView], [forceRecalculation]).
 class GraphViewController {
   _GraphViewState? _state;
   final TransformationController? transformationController;
 
+  /// Tracks which nodes are currently collapsed (children hidden).
   final Map<Node, bool> collapsedNodes = {};
+
+  /// Tracks nodes currently being revealed by an expand animation.
   final Map<Node, bool> expandingNodes = {};
+
+  /// Maps each hidden node to the collapsed ancestor that hides it.
   final Map<Node, Node> hiddenBy = {};
 
+  /// The most recently collapsed node (used for edge fade-out animation).
   Node? collapsedNode;
+
+  /// The node to center the view on after a collapse/expand operation.
   Node? focusedNode;
 
   GraphViewController({
@@ -55,27 +73,36 @@ class GraphViewController {
 
   void _detach() => _state = null;
 
+  /// Smoothly animates the view to center on the node with the given [key].
   void animateToNode(ValueKey key) => _state?.jumpToNodeUsingKey(key, true);
 
+  /// Instantly jumps the view to center on the node with the given [key].
   void jumpToNode(ValueKey key) => _state?.jumpToNodeUsingKey(key, false);
 
+  /// Smoothly animates the transformation matrix to the [target].
   void animateToMatrix(Matrix4 target) => _state?.animateToMatrix(target);
 
+  /// Resets the view to the identity transformation (no pan, no zoom).
   void resetView() => _state?.resetView();
 
+  /// Scales and translates the view to fit all visible nodes within the viewport.
   void zoomToFit() => _state?.zoomToFit();
 
+  /// Forces the layout algorithm to recalculate all node positions.
   void forceRecalculation() => _state?.forceRecalculation();
 
-  // Visibility management methods
+  /// Whether [node] is currently collapsed (its children are hidden).
   bool isNodeCollapsed(Node node) => collapsedNodes.containsKey(node);
 
+  /// Whether [node] is hidden by a collapsed ancestor.
   bool isNodeHidden(Node node) => hiddenBy.containsKey(node);
 
+  /// Whether [node] is visible in the current graph view.
   bool isNodeVisible(Graph graph, Node node) {
     return !hiddenBy.containsKey(node);
   }
 
+  /// Walks up the predecessor chain to find the nearest visible ancestor of [node].
   Node? findClosestVisibleAncestor(Graph graph, Node node) {
     var current = graph.predecessorsOf(node).firstOrNull;
 
@@ -117,6 +144,7 @@ class GraphViewController {
     }
   }
 
+  /// Expands a collapsed [node], revealing its children. Set [animate] to trigger a smooth transition.
   void expandNode(Graph graph, Node node, {animate = false}) {
     collapsedNodes.remove(node);
     hiddenBy.removeWhere((hiddenNode, hiddenBy) => hiddenBy == node);
@@ -130,6 +158,7 @@ class GraphViewController {
     forceRecalculation();
   }
 
+  /// Collapses [node], hiding all its descendants. Set [animate] to trigger a smooth transition.
   void collapseNode(Graph graph, Node node, {animate = false}) {
     if (graph.hasSuccessor(node)) {
       collapsedNodes[node] = true;
@@ -143,6 +172,7 @@ class GraphViewController {
     expandingNodes.clear();
   }
 
+  /// Toggles [node] between collapsed and expanded states.
   void toggleNodeExpanded(Graph graph, Node node, {animate = false}) {
     if (isNodeCollapsed(node)) {
       expandNode(graph, node, animate: animate);
@@ -151,6 +181,7 @@ class GraphViewController {
     }
   }
 
+  /// Returns edges that should fade out during the current collapse animation.
   List<Edge> getCollapsingEdges(Graph graph) {
     if (collapsedNode == null) return [];
 
@@ -159,6 +190,7 @@ class GraphViewController {
     }).toList();
   }
 
+  /// Returns edges that should fade in during the current expand animation.
   List<Edge> getExpandingEdges(Graph graph) {
     final expandingEdges = <Edge>[];
 
@@ -172,7 +204,7 @@ class GraphViewController {
     return expandingEdges;
   }
 
-  // Additional convenience methods for setting initial state
+  /// Pre-collapses the given [nodes] before the first layout pass.
   void setInitiallyCollapsedNodes(Graph graph, List<Node> nodes) {
     for (final node in nodes) {
       collapsedNodes[node] = true;
@@ -181,6 +213,7 @@ class GraphViewController {
     }
   }
 
+  /// Pre-collapses nodes matching the given [keys] before the first layout pass.
   void setInitiallyCollapsedByKeys(Graph graph, Set<ValueKey> keys) {
     for (final key in keys) {
       try {
@@ -194,12 +227,15 @@ class GraphViewController {
     }
   }
 
+  /// Whether [node] is currently being revealed by an expand animation.
   bool isNodeExpanding(Node node) => expandingNodes.containsKey(node);
 
+  /// Clears the collapsing animation state after the animation completes.
   void removeCollapsingNodes() {
     collapsedNode = null;
   }
 
+  /// Centers the view on the current [focusedNode] and clears it.
   void jumpToFocusedNode() {
     if (focusedNode != null) {
       final nodeCenter = Offset(
@@ -212,6 +248,8 @@ class GraphViewController {
   }
 }
 
+/// Manages the visible subset of a [Graph] based on collapse state,
+/// builds node widgets, and runs the layout algorithm.
 class GraphChildDelegate {
   final Graph graph;
   final Algorithm algorithm;
@@ -229,6 +267,7 @@ class GraphChildDelegate {
     this.centerGraph = false,
   });
 
+  /// Returns the visible graph including collapsing edges (for fade-out animation).
   Graph getVisibleGraph() {
     if (_cachedVisibleGraph != null && !_needsRecalculation) {
       return _cachedVisibleGraph!;
@@ -244,6 +283,7 @@ class GraphChildDelegate {
     return visibleGraph;
   }
 
+  /// Returns a graph containing only currently visible nodes and their edges.
   Graph getVisibleGraphOnly() {
     final visibleGraph = Graph();
     for (final edge in graph.edges) {
@@ -270,6 +310,7 @@ class GraphChildDelegate {
     return result;
   }
 
+  /// Executes the layout algorithm on the visible graph and returns the resulting size.
   Size runAlgorithm() {
     final visibleGraph = getVisibleGraphOnly();
 
@@ -295,6 +336,11 @@ class GraphChildDelegate {
   }
 }
 
+/// A widget that displays a [Graph] using a layout [Algorithm].
+///
+/// Use the default constructor for non-interactive graphs embedded in scrollable layouts.
+/// Use [GraphView.builder] for interactive pan/zoom with [InteractiveViewer], node
+/// collapse/expand, and programmatic navigation via [GraphViewController].
 class GraphView extends StatefulWidget {
   final Graph graph;
   final Algorithm algorithm;

--- a/lib/edgerenderer/ArrowEdgeRenderer.dart
+++ b/lib/edgerenderer/ArrowEdgeRenderer.dart
@@ -1,12 +1,22 @@
 part of graphview;
 
+/// The angular spread (in radians) of the arrowhead triangle.
 const double ARROW_DEGREES = 0.5;
+
+/// The length (in logical pixels) of the arrowhead triangle.
 const double ARROW_LENGTH = 10;
 
+/// Renders edges as straight lines with optional directional arrowheads.
+///
+/// Supports self-loop rendering via cubic Bezier arcs and clips lines
+/// at node boundaries so arrows point to the edge of the node widget.
 class ArrowEdgeRenderer extends EdgeRenderer {
   var trianglePath = Path();
+
+  /// When true, renders lines without arrowheads.
   final bool noArrow;
 
+  /// Creates an arrow edge renderer. Set [noArrow] to true for plain lines.
   ArrowEdgeRenderer({this.noArrow = false});
 
   Offset _getNodeCenter(Node node) {
@@ -135,6 +145,7 @@ class ArrowEdgeRenderer extends EdgeRenderer {
     return null;
   }
 
+  /// Draws an arrowhead triangle at the end of a line and returns its centroid.
   Offset drawTriangle(Canvas canvas, Paint paint, double lineStartX,
       double lineStartY, double arrowTipX, double arrowTipY) {
     // Calculate direction from line start to arrow tip, then flip 180° to point backwards from tip
@@ -166,6 +177,7 @@ class ArrowEdgeRenderer extends EdgeRenderer {
     return Offset(triangleCenterX, triangleCenterY);
   }
 
+  /// Clips a line endpoint to the boundary of the destination node rectangle.
   List<double> clipLineEnd(
       double startX,
       double startY,
@@ -219,6 +231,7 @@ class ArrowEdgeRenderer extends EdgeRenderer {
     return [startX, startY, clippedStopX, clippedStopY];
   }
 
+  /// Clips a line to the boundary of the [destination] node.
   List<double> clipLine(double startX, double startY, double stopX,
       double stopY, Node destination) {
     final resultLine = [startX, startY, stopX, stopY];

--- a/lib/edgerenderer/EdgeRenderer.dart
+++ b/lib/edgerenderer/EdgeRenderer.dart
@@ -1,14 +1,22 @@
 part of graphview;
 
+/// Abstract base class for rendering edges between nodes on a canvas.
+///
+/// Provides shared utilities for line styling ([drawStyledLine], [drawStyledPath]),
+/// self-loop path construction ([buildSelfLoopPath]), and node position lookups.
 abstract class EdgeRenderer {
   Map<Node, Offset>? _animatedPositions;
 
+  /// Sets animated positions used during collapse/expand transitions.
   void setAnimatedPositions(Map<Node, Offset> positions) => _animatedPositions = positions;
 
+  /// Returns the current position of [node], using animated position if available.
   Offset getNodePosition(Node node) => _animatedPositions?[node] ?? node.position;
 
+  /// Renders a single [edge] on the [canvas] using the given [paint].
   void renderEdge(Canvas canvas, Edge edge, Paint paint);
 
+  /// Returns the center point of [node] based on its position and size.
   Offset getNodeCenter(Node node) {
     final nodePosition = getNodePosition(node);
     return Offset(
@@ -199,10 +207,17 @@ abstract class EdgeRenderer {
   }
 }
 
+/// Result of building a self-loop edge path, containing geometry for arrow rendering.
 class LoopRenderResult {
+  /// The cubic Bezier path forming the loop arc.
   final Path path;
+
+  /// The position where the arrowhead base starts.
   final Offset arrowBase;
+
+  /// The position of the arrowhead tip.
   final Offset arrowTip;
 
+  /// Creates a loop render result with the given [path], [arrowBase], and [arrowTip].
   const LoopRenderResult(this.path, this.arrowBase, this.arrowTip);
 }

--- a/lib/forcedirected/FruchtermanReingoldAlgorithm.dart
+++ b/lib/forcedirected/FruchtermanReingoldAlgorithm.dart
@@ -1,5 +1,10 @@
 part of graphview;
 
+/// Force-directed graph layout using the Fruchterman-Reingold algorithm.
+///
+/// Simulates attractive forces along edges and repulsive forces between all nodes,
+/// iterating until the layout converges or the maximum iteration count is reached.
+/// Best suited for arbitrary undirected or directed graphs without a tree structure.
 class FruchtermanReingoldAlgorithm implements Algorithm {
   static const double DEFAULT_TICK_FACTOR = 0.1;
   static const double CONVERGENCE_THRESHOLD = 1.0;

--- a/lib/forcedirected/FruchtermanReingoldConfiguration.dart
+++ b/lib/forcedirected/FruchtermanReingoldConfiguration.dart
@@ -1,5 +1,6 @@
 part of graphview;
 
+/// Configuration for the [FruchtermanReingoldAlgorithm] force-directed layout.
 class FruchtermanReingoldConfiguration {
   static const int DEFAULT_ITERATIONS = 100;
   static const double DEFAULT_REPULSION_RATE = 0.2;
@@ -11,15 +12,34 @@ class FruchtermanReingoldConfiguration {
   static const double DEFAULT_LERP_FACTOR = 0.05;
   static const double DEFAULT_MOVEMENT_THRESHOLD = 0.6;
 
+  /// Maximum number of simulation iterations.
   int iterations;
+
+  /// Strength of the repulsive force between nodes.
   double repulsionRate;
+
+  /// Percentage of graph area used for repulsion calculation.
   double repulsionPercentage;
+
+  /// Strength of the attractive force along edges.
   double attractionRate;
+
+  /// Percentage of graph area used for attraction calculation.
   double attractionPercentage;
+
+  /// Padding between node clusters in logical pixels.
   int clusterPadding;
+
+  /// Minimum distance threshold to avoid division by zero in repulsion.
   double epsilon;
+
+  /// Interpolation factor for smooth position transitions (0.0 to 1.0).
   double lerpFactor;
+
+  /// Minimum movement threshold below which the simulation stops early.
   double movementThreshold;
+
+  /// Whether to randomize initial node positions before simulation.
   bool shuffleNodes = true;
 
   FruchtermanReingoldConfiguration({

--- a/lib/layered/EiglspergerAlgorithm.dart
+++ b/lib/layered/EiglspergerAlgorithm.dart
@@ -1,5 +1,6 @@
 part of graphview;
 
+/// A container of [Segment]s used during Eiglsperger layer compaction.
 class ContainerX {
   List<Segment> segments = [];
   int index = -1;
@@ -69,6 +70,7 @@ class ContainerX {
   String toString() => 'Container(${segments.length} segments, pos: $pos, measure: $measure)';
 }
 
+/// A pair of [ContainerX] instances resulting from a split operation.
 class ContainerPair {
   final ContainerX left;
   final ContainerX right;
@@ -76,7 +78,7 @@ class ContainerPair {
   ContainerPair(this.left, this.right);
 }
 
-// Segment represents a vertical edge span between P and Q vertices
+/// A vertical edge span between a P-vertex (top) and Q-vertex (bottom).
 class Segment {
   final Node pVertex; // top vertex (P-vertex)
   final Node qVertex; // bottom vertex (Q-vertex)
@@ -97,6 +99,7 @@ class Segment {
   String toString() => 'Segment($id)';
 }
 
+/// Internal data attached to each node during [EiglspergerAlgorithm] execution.
 class EiglspergerNodeData {
   bool isDummy = false;
   bool isPVertex = false;
@@ -117,11 +120,12 @@ class EiglspergerNodeData {
   bool get isReversed => reversed.isNotEmpty;
 }
 
+/// Internal data attached to each edge during [EiglspergerAlgorithm] execution.
 class EiglspergerEdgeData {
   List<double> bendPoints = [];
 }
 
-// Virtual edge for container connections
+/// A virtual edge representing a connection between containers during layer compaction.
 class VirtualEdge {
   final dynamic source;
   final dynamic target;
@@ -133,14 +137,14 @@ class VirtualEdge {
   String toString() => 'VirtualEdge($source -> $target, weight: $weight)';
 }
 
-// Layer element that can be either a Node or Container
+/// Base class for elements in a layer — either a [NodeElement] or [ContainerElement].
 abstract class LayerElement {
   int index = -1;
   int pos = -1;
   double measure = -1;
 }
 
-// Node wrapper for layer elements
+/// Wraps a [Node] as a [LayerElement] for mixed node/container layers.
 class NodeElement extends LayerElement {
   final Node node;
   NodeElement(this.node);
@@ -149,7 +153,7 @@ class NodeElement extends LayerElement {
   String toString() => 'NodeElement(${node.toString()})';
 }
 
-// Container wrapper for layer elements
+/// Wraps a [ContainerX] as a [LayerElement] for mixed node/container layers.
 class ContainerElement extends LayerElement {
   final ContainerX container;
   ContainerElement(this.container);
@@ -158,6 +162,8 @@ class ContainerElement extends LayerElement {
   String toString() => 'ContainerElement(${container.toString()})';
 }
 
+/// Layered graph layout using the Eiglsperger algorithm, an optimization
+/// of the Sugiyama framework that uses segment containers for more compact layouts.
 class EiglspergerAlgorithm extends Algorithm {
   Map<Node, EiglspergerNodeData> nodeData = {};
   final Map<Edge, EiglspergerEdgeData> _edgeData = {};

--- a/lib/layered/SugiyamaAlgorithm.dart
+++ b/lib/layered/SugiyamaAlgorithm.dart
@@ -1,5 +1,11 @@
 part of graphview;
 
+/// Hierarchical/layered graph layout using the Sugiyama framework.
+///
+/// Implements a 5-phase approach: cycle removal, layer assignment,
+/// node ordering (crossing minimization), coordinate assignment, and
+/// edge denormalization. Handles arbitrary directed graphs by temporarily
+/// reversing edges that create cycles.
 class SugiyamaAlgorithm extends Algorithm {
   Map<Node, SugiyamaNodeData> nodeData = {};
   Map<Edge, SugiyamaEdgeData> edgeData = {};

--- a/lib/layered/SugiyamaConfiguration.dart
+++ b/lib/layered/SugiyamaConfiguration.dart
@@ -1,29 +1,55 @@
 part of graphview;
 
+/// Configuration for the [SugiyamaAlgorithm] layered graph layout.
 class SugiyamaConfiguration {
+  /// Root at top, leaves at bottom.
   static const ORIENTATION_TOP_BOTTOM = 1;
+
+  /// Root at bottom, leaves at top.
   static const ORIENTATION_BOTTOM_TOP = 2;
+
+  /// Root at left, leaves at right.
   static const ORIENTATION_LEFT_RIGHT = 3;
+
+  /// Root at right, leaves at left.
   static const ORIENTATION_RIGHT_LEFT = 4;
+
   static const DEFAULT_ORIENTATION = 1;
   static const int DEFAULT_ITERATIONS = 10;
-
   static const int X_SEPARATION = 100;
   static const int Y_SEPARATION = 100;
 
+  /// Vertical spacing between layers.
   int levelSeparation = Y_SEPARATION;
+
+  /// Horizontal spacing between nodes within a layer.
   int nodeSeparation = X_SEPARATION;
+
+  /// Layout direction. Use ORIENTATION_* constants.
   int orientation = DEFAULT_ORIENTATION;
+
+  /// Number of iterations for crossing minimization.
   int iterations = DEFAULT_ITERATIONS;
+
+  /// Shape used for edge bend points (sharp, curved, or max-curved).
   BendPointShape bendPointShape = SharpBendPointShape();
+
+  /// Strategy for assigning x-coordinates to nodes within layers.
   CoordinateAssignment coordinateAssignment = CoordinateAssignment.Average;
 
+  /// Strategy for assigning nodes to layers.
   LayeringStrategy layeringStrategy = LayeringStrategy.topDown;
+
+  /// Strategy for minimizing edge crossings between layers.
   CrossMinimizationStrategy crossMinimizationStrategy = CrossMinimizationStrategy.simple;
+
+  /// Strategy for removing cycles in the input graph.
   CycleRemovalStrategy cycleRemovalStrategy = CycleRemovalStrategy.greedy;
 
+  /// Whether to apply post-processing to straighten edges.
   bool postStraighten = true;
 
+  /// Whether to draw arrowhead triangles on edge endpoints.
   bool addTriangleToEdge = true;
 
   int getLevelSeparation() {
@@ -39,40 +65,63 @@ class SugiyamaConfiguration {
   }
 }
 
+/// Strategy for assigning x-coordinates to nodes within layers.
 enum CoordinateAssignment {
-  DownRight, // 0
-  DownLeft, // 1
-  UpRight, // 2
-  UpLeft, // 3
-  Average, // 4
+  /// Assign coordinates favoring down-right placement.
+  DownRight,
+  /// Assign coordinates favoring down-left placement.
+  DownLeft,
+  /// Assign coordinates favoring up-right placement.
+  UpRight,
+  /// Assign coordinates favoring up-left placement.
+  UpLeft,
+  /// Average of all four directional assignments.
+  Average,
 }
 
+/// Strategy for assigning nodes to layers in the Sugiyama framework.
 enum LayeringStrategy {
+  /// Simple top-down depth-first layer assignment.
   topDown,
+  /// Assigns layers based on the longest path from source nodes.
   longestPath,
+  /// Coffman-Graham layering with bounded layer width.
   coffmanGraham,
+  /// Optimal layering via network simplex (most expensive).
   networkSimplex
 }
 
+/// Strategy for minimizing edge crossings between adjacent layers.
 enum CrossMinimizationStrategy {
+  /// Simple median/barycenter heuristic.
   simple,
+  /// Accumulator tree-based crossing count for faster minimization.
   accumulatorTree
 }
 
+/// Strategy for removing cycles from a directed graph before layering.
 enum CycleRemovalStrategy {
+  /// Depth-first search based cycle removal.
   dfs,
+  /// Greedy heuristic cycle removal.
   greedy,
 }
 
+/// Base class for edge bend point rendering shapes.
 abstract class BendPointShape {}
 
+/// Renders bend points as sharp 90-degree angles.
 class SharpBendPointShape extends BendPointShape {}
 
+/// Renders bend points with maximum curvature.
 class MaxCurvedBendPointShape extends BendPointShape {}
 
+/// Renders bend points with a configurable curve radius.
 class CurvedBendPointShape extends BendPointShape {
+  /// The length of the curved segment at each bend point.
   final double curveLength;
 
+  /// Creates a curved bend point shape with the given [curveLength].
   CurvedBendPointShape({
     required this.curveLength,
   });

--- a/lib/layered/SugiyamaEdgeData.dart
+++ b/lib/layered/SugiyamaEdgeData.dart
@@ -1,5 +1,7 @@
 part of graphview;
 
+/// Internal data attached to each edge during [SugiyamaAlgorithm] execution.
 class SugiyamaEdgeData {
+  /// Coordinates of intermediate bend points along the edge path.
   List<double> bendPoints = [];
 }

--- a/lib/layered/SugiyamaEdgeRenderer.dart
+++ b/lib/layered/SugiyamaEdgeRenderer.dart
@@ -1,5 +1,7 @@
 part of graphview;
 
+/// Renders edges for [SugiyamaAlgorithm] layouts with support for
+/// bend points, dummy nodes, and configurable bend point shapes.
 class SugiyamaEdgeRenderer extends ArrowEdgeRenderer {
   Map<Node, SugiyamaNodeData> nodeData;
   Map<Edge, SugiyamaEdgeData> edgeData;

--- a/lib/layered/SugiyamaNodeData.dart
+++ b/lib/layered/SugiyamaNodeData.dart
@@ -1,5 +1,6 @@
 part of graphview;
 
+/// Internal data attached to each node during [SugiyamaAlgorithm] execution.
 class SugiyamaNodeData {
   Set<Node> reversed = {};
   bool isDummy = false;

--- a/lib/mindmap/MindMapAlgorithm.dart
+++ b/lib/mindmap/MindMapAlgorithm.dart
@@ -1,11 +1,23 @@
 part of graphview;
 
-enum MindmapSide { LEFT, RIGHT, ROOT }
+/// Which side of the root a subtree is placed on in a mindmap layout.
+enum MindmapSide {
+  /// Subtree placed to the left of the root.
+  LEFT,
+  /// Subtree placed to the right of the root.
+  RIGHT,
+  /// The root node itself.
+  ROOT
+}
 
 class _SideData {
   MindmapSide side = MindmapSide.ROOT;
 }
 
+/// A mindmap layout that distributes children alternately to the left and right of the root.
+///
+/// Extends [BuchheimWalkerAlgorithm] for spacing calculations, then repositions
+/// subtrees horizontally around a central root node.
 class MindmapAlgorithm extends BuchheimWalkerAlgorithm {
   final Map<Node, _SideData> _side = {};
 

--- a/lib/mindmap/MindmapEdgeRenderer.dart
+++ b/lib/mindmap/MindmapEdgeRenderer.dart
@@ -1,5 +1,7 @@
 part of graphview;
 
+/// Edge renderer for mindmap layouts that auto-detects orientation
+/// based on child position relative to the root.
 class MindmapEdgeRenderer extends TreeEdgeRenderer {
   MindmapEdgeRenderer(BuchheimWalkerConfiguration configuration)
       : super(configuration);

--- a/lib/tree/BaloonLayoutAlgorithm.dart
+++ b/lib/tree/BaloonLayoutAlgorithm.dart
@@ -1,8 +1,10 @@
 part of graphview;
 
-// Polar coordinate representation
+/// A point in polar coordinates, used by radial/balloon layout algorithms.
 class PolarPoint {
-  final double theta; // angle in radians
+  /// The angle in radians.
+  final double theta;
+  /// The distance from the origin.
   final double radius;
 
   const PolarPoint(this.theta, this.radius);
@@ -25,6 +27,10 @@ class PolarPoint {
   String toString() => 'PolarPoint(theta: $theta, radius: $radius)';
 }
 
+/// Radial tree layout that arranges children in circular groups around their parent.
+///
+/// Each subtree is allocated an angular wedge proportional to its size,
+/// producing a balloon-like radial visualization.
 class BalloonLayoutAlgorithm extends Algorithm {
   late BuchheimWalkerConfiguration config;
   final Map<Node, TreeLayoutNodeData> nodeData = {};

--- a/lib/tree/BuchheimWalkerAlgorithm.dart
+++ b/lib/tree/BuchheimWalkerAlgorithm.dart
@@ -1,5 +1,10 @@
 part of graphview;
 
+/// Positions nodes in a tree layout using Buchheim-Walker's algorithm.
+///
+/// Produces compact, aesthetically pleasing tree drawings with O(n) time complexity.
+/// Requires an acyclic graph; throws if cycles are detected.
+/// Supports four orientations via [BuchheimWalkerConfiguration].
 class BuchheimWalkerAlgorithm extends Algorithm {
   Map<Node, BuchheimWalkerNodeData> nodeData = {};
   double minNodeHeight = double.infinity;

--- a/lib/tree/BuchheimWalkerConfiguration.dart
+++ b/lib/tree/BuchheimWalkerConfiguration.dart
@@ -1,18 +1,39 @@
 part of graphview;
 
+/// Configuration for tree layout algorithms ([BuchheimWalkerAlgorithm], [TidierTreeLayoutAlgorithm], etc.).
+///
+/// Controls spacing between siblings, levels, and subtrees, as well as layout orientation.
 class BuchheimWalkerConfiguration {
+  /// Horizontal spacing between sibling nodes.
   int siblingSeparation = DEFAULT_SIBLING_SEPARATION;
+
+  /// Vertical spacing between tree levels.
   int levelSeparation = DEFAULT_LEVEL_SEPARATION;
+
+  /// Horizontal spacing between adjacent subtrees.
   int subtreeSeparation = DEFAULT_SUBTREE_SEPARATION;
+
+  /// Layout direction. Use ORIENTATION_* constants.
   int orientation = DEFAULT_ORIENTATION;
+
+  /// Root at top, leaves at bottom.
   static const ORIENTATION_TOP_BOTTOM = 1;
+
+  /// Root at bottom, leaves at top.
   static const ORIENTATION_BOTTOM_TOP = 2;
+
+  /// Root at left, leaves at right.
   static const ORIENTATION_LEFT_RIGHT = 3;
+
+  /// Root at right, leaves at left.
   static const ORIENTATION_RIGHT_LEFT = 4;
+
   static const DEFAULT_SIBLING_SEPARATION = 100;
   static const DEFAULT_SUBTREE_SEPARATION = 100;
   static const DEFAULT_LEVEL_SEPARATION = 100;
   static const DEFAULT_ORIENTATION = 1;
+
+  /// Whether to use curved Bezier connections instead of straight lines.
   bool useCurvedConnections = true;
 
   int getSiblingSeparation() {

--- a/lib/tree/BuchheimWalkerNodeData.dart
+++ b/lib/tree/BuchheimWalkerNodeData.dart
@@ -1,5 +1,6 @@
 part of graphview;
 
+/// Internal data attached to each node during [BuchheimWalkerAlgorithm] execution.
 class BuchheimWalkerNodeData {
   Node? ancestor;
   Node? thread;

--- a/lib/tree/CircleLayoutAlgorithm.dart
+++ b/lib/tree/CircleLayoutAlgorithm.dart
@@ -1,8 +1,14 @@
 part of graphview;
 
+/// Configuration for [CircleLayoutAlgorithm].
 class CircleLayoutConfiguration {
+  /// Circle radius in logical pixels. Use 0 for auto-calculation.
   final double radius;
+
+  /// Whether to reorder nodes to minimize edge crossings.
   final bool reduceEdgeCrossing;
+
+  /// Maximum number of edges to consider during crossing reduction.
   final int reduceEdgeCrossingMaxEdges;
 
   CircleLayoutConfiguration({
@@ -12,6 +18,7 @@ class CircleLayoutConfiguration {
   });
 }
 
+/// Arranges all nodes evenly spaced on a circle with optional edge crossing reduction.
 class CircleLayoutAlgorithm extends Algorithm {
   final CircleLayoutConfiguration config;
   double _radius = 0.0;

--- a/lib/tree/RadialTreeLayoutAlgorithm.dart
+++ b/lib/tree/RadialTreeLayoutAlgorithm.dart
@@ -1,5 +1,6 @@
 part of graphview;
 
+/// Internal data attached to each node during tree layout computation.
 class TreeLayoutNodeData {
   Rectangle? bounds;
   int depth = 0;
@@ -10,6 +11,8 @@ class TreeLayoutNodeData {
   TreeLayoutNodeData();
 }
 
+/// Positions tree nodes using polar coordinates where depth determines
+/// the radius and sibling order determines the angle.
 class RadialTreeLayoutAlgorithm extends Algorithm {
   late BuchheimWalkerConfiguration config;
   final Map<Node, TreeLayoutNodeData> nodeData = {};

--- a/lib/tree/TidierTreeLayoutAlgorithm.dart
+++ b/lib/tree/TidierTreeLayoutAlgorithm.dart
@@ -1,5 +1,6 @@
 part of graphview;
 
+/// Internal data attached to each node during [TidierTreeLayoutAlgorithm] execution.
 class TidierTreeNodeData {
   int mod = 0;
   Node? thread;
@@ -14,6 +15,8 @@ class TidierTreeNodeData {
   TidierTreeNodeData();
 }
 
+/// An improved tree layout algorithm that produces tidier drawings
+/// with better spacing than [BuchheimWalkerAlgorithm] for complex hierarchies.
 class TidierTreeLayoutAlgorithm extends Algorithm {
   late BuchheimWalkerConfiguration config;
   final Map<Node, TidierTreeNodeData> nodeData = {};

--- a/lib/tree/TreeEdgeRenderer.dart
+++ b/lib/tree/TreeEdgeRenderer.dart
@@ -1,5 +1,9 @@
 part of graphview;
 
+/// Renders edges as curved or straight connections for tree-based layouts.
+///
+/// Supports all four orientations and produces paths that follow the
+/// tree hierarchy visually (parent-to-child connections).
 class TreeEdgeRenderer extends EdgeRenderer {
   BuchheimWalkerConfiguration configuration;
 


### PR DESCRIPTION
## Summary
- Adds `///` dartdoc comments to 214 public API elements across all 23 library files
- Raises documentation coverage from 7.0% (52/746) to 35.7% (266/746), achieving the full 20/20 pub.dev documentation score
- No functional changes — only dartdoc comments added

### Documented elements include:
- Core data structures: `Graph`, `Node`, `Edge`, `GraphObserver`, `LineType`
- Main widget: `GraphView`, `GraphViewController`, `GraphChildDelegate`
- All 8 layout algorithms: `BuchheimWalkerAlgorithm`, `SugiyamaAlgorithm`, `FruchtermanReingoldAlgorithm`, `BalloonLayoutAlgorithm`, `CircleLayoutAlgorithm`, `RadialTreeLayoutAlgorithm`, `TidierTreeLayoutAlgorithm`, `MindmapAlgorithm`
- Configuration classes: `BuchheimWalkerConfiguration`, `SugiyamaConfiguration`, `FruchtermanReingoldConfiguration`, `CircleLayoutConfiguration`
- Edge renderers: `EdgeRenderer`, `ArrowEdgeRenderer`, `TreeEdgeRenderer`, `SugiyamaEdgeRenderer`, `MindmapEdgeRenderer`
- Sugiyama enums & shapes: `CoordinateAssignment`, `LayeringStrategy`, `CrossMinimizationStrategy`, `CycleRemovalStrategy`, `BendPointShape` and subclasses
- Eiglsperger types: `ContainerX`, `Segment`, `LayerElement`, etc.

## Test plan
- [x] `flutter test` — all 37 tests pass
- [x] `flutter analyze` — no new issues introduced (15 pre-existing infos/warnings)
- [x] `pana .` — documentation score confirmed at 20/20

🤖 Generated with [Claude Code](https://claude.com/claude-code)